### PR TITLE
update dockerfile with pre-built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
-FROM node:10
-
-# Install Chrome headless
-RUN apt-get update
-RUN apt-get install -y wget xvfb unzip
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-RUN apt-get update
-RUN apt-get install -y google-chrome-stable
+FROM courb/ember-test
 
 WORKDIR /app
 
 COPY package.json ./
 
-RUN npm install -g ember-cli@3.5.1
-RUN npm install --quiet
+RUN yarn install --silent
 
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM courb/ember-test
 WORKDIR /app
 
 COPY package.json ./
-
+COPY yarn.lock ./
 RUN yarn install --silent
 
 COPY . ./


### PR DESCRIPTION
* uses a custom pre-built image from docker hub, to speed up test environment setup.

@fnv @jyotishkabiswas @suzidao FYI, the image is currently in my private docker hub account. we can create a company organization and move it over there, in case docker is a strategy that works for us moving forward.