### PR TITLE
Remove disabled button hover property

### DIFF
--- a/app/styles/courb-common-ui/components/courb-button.scss
+++ b/app/styles/courb-common-ui/components/courb-button.scss
@@ -19,6 +19,7 @@
   &:disabled, &[disabled]{
     cursor: not-allowed;
     opacity: 0.6;
+    pointer-events: none;
   }
 
   &--link {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164897480

Disabled buttons should not have a hover event.

![DisabledHoverFix](https://user-images.githubusercontent.com/12685178/55349572-0bb1d500-5488-11e9-963c-391375681ce5.gif)
