### PR TITLE
support disabled attribute on courb-input

### DIFF
--- a/addon/components/courb-input.js
+++ b/addon/components/courb-input.js
@@ -39,19 +39,27 @@ export default Component.extend({
   maxLength: null,
 
   /**
-   * <input/> type attripute
+   * <input> type attripute
    * @type String
    */
   type: 'text',
 
   /**
-   * <input/> placeholder attribute
+   * <input> placeholder attribute
    * @type String?
    */
   placeholder: null,
 
+  /**
+   * <input> disabled attribute
+   * @type Boolean?
+   */
+  disabled: false,
+
   actions: {
     /**
+     * Call given `oninput` action with input value. If `maxLength` property is
+     * set, the char number of value will be limited to it.
      * @action setValidProperty
      * @param { target } HTMLInputEvent
      */

--- a/addon/tailwind/components/forms.css
+++ b/addon/tailwind/components/forms.css
@@ -20,6 +20,10 @@
   @apply .relative .flex .justify-between .items-center .h-16 .m-0 .p-4 .bg-grey-lightest .border .border-grey .border-solid;
 }
 
+.courb-input input[disabled] {
+  @apply .cursor-not-allowed;
+}
+
 .courb-char-count {
   @apply .text-sm .font-light;
 }

--- a/addon/templates/components/courb-input.hbs
+++ b/addon/templates/components/courb-input.hbs
@@ -5,5 +5,6 @@
   oninput={{action "setValidProperty"}}
   value={{value}}
   placeholder={{placeholder}}
+  disabled={{disabled}}
 >
 {{yield}}

--- a/tests/integration/components/courb-input-test.js
+++ b/tests/integration/components/courb-input-test.js
@@ -15,6 +15,7 @@ module('Integration | Component | courb-input', function(hooks) {
     assert.dom('input').hasValue('my value');
     assert.dom('input').hasAttribute('name', 'my-name');
     assert.dom('input').hasAttribute('placeholder', 'my placeholder text');
+    assert.dom('input').doesNotHaveAttribute('disabled');
 
     await render(hbs`
       {{#courb-input}}
@@ -44,5 +45,10 @@ module('Integration | Component | courb-input', function(hooks) {
     await fillIn('input', 'my input is too long');
     assert.dom('input').hasValue('my');
     assert.equal(this.inputValue, 'my');
+  });
+
+  test('it sets disabled attribute', async function(assert) {
+    await render(hbs`{{courb-input disabled=true}}`);
+    assert.dom('input').hasAttribute('disabled', '');
   });
 });


### PR DESCRIPTION
* adds support to use `disabled` on `{{court-input}}`