### PR TITLE
adds blur and focus event handlers to courb-input

### DIFF
--- a/addon/components/courb-input.js
+++ b/addon/components/courb-input.js
@@ -56,6 +56,22 @@ export default Component.extend({
    */
   disabled: false,
 
+  /**
+   * Action handler for <input> blur event
+   * @type Action?
+   */
+  onblur() {
+    return;
+  },
+
+  /**
+   * Action handler for <input> focus event
+   * @type Action?
+   */
+  onfocus() {
+    return;
+  },
+
   actions: {
     /**
      * Call given `oninput` action with input value. If `maxLength` property is

--- a/addon/components/courb-input.js
+++ b/addon/components/courb-input.js
@@ -57,6 +57,14 @@ export default Component.extend({
   disabled: false,
 
   /**
+   * Action handler for <input> input event
+   * @type Action?
+   */
+  oninput() {
+    return;
+  },
+
+  /**
    * Action handler for <input> blur event
    * @type Action?
    */

--- a/addon/templates/components/courb-input.hbs
+++ b/addon/templates/components/courb-input.hbs
@@ -3,6 +3,8 @@
   class="bg-transparent border-0 flex-grow p-0 focus:outline-none"
   name={{name}}
   oninput={{action "setValidProperty"}}
+  onblur={{action onblur}}
+  onfocus={{action onfocus}}
   value={{value}}
   placeholder={{placeholder}}
   disabled={{disabled}}

--- a/tests/integration/components/courb-input-test.js
+++ b/tests/integration/components/courb-input-test.js
@@ -17,6 +17,9 @@ module('Integration | Component | courb-input', function(hooks) {
     assert.dom('input').hasAttribute('placeholder', 'my placeholder text');
     assert.dom('input').doesNotHaveAttribute('disabled');
 
+    await fillIn('input', 'my new value');
+    assert.dom('input').hasValue('my new value');
+
     await render(hbs`
       {{#courb-input}}
         <span class="wrapped-content">hello courb-input</span>

--- a/tests/integration/components/courb-input-test.js
+++ b/tests/integration/components/courb-input-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { render, fillIn, focus, blur } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | courb-input', function(hooks) {
@@ -50,5 +50,20 @@ module('Integration | Component | courb-input', function(hooks) {
   test('it sets disabled attribute', async function(assert) {
     await render(hbs`{{courb-input disabled=true}}`);
     assert.dom('input').hasAttribute('disabled', '');
+  });
+
+  test('it calls external focus and blur actions', async function(assert) {
+    assert.expect(4);
+    this.set('onfocus', event => {
+      assert.ok(event instanceof Event, 'action is called with event argument');
+      assert.equal(event.type, 'focus', 'event argument is of type "focus"');
+    });
+    this.set('onblur', event => {
+      assert.ok(event instanceof Event, 'action is called with event argument');
+      assert.equal(event.type, 'blur', 'event argument is of type "blur"');
+    });
+    await render(hbs`{{courb-input onfocus=onfocus onblur=onblur}}`);
+    await focus('input');
+    await blur('input');
   });
 });


### PR DESCRIPTION
* call actions on `blur` and `focus` events on the court-input `input`.
* fixes issue when input event handler was undefined
* component tests fully cover this addition