### PR TITLE
Add white button class

### DIFF
--- a/app/styles/courb-common-ui/components/courb-button.scss
+++ b/app/styles/courb-common-ui/components/courb-button.scss
@@ -56,6 +56,12 @@
     &:hover { background-color: $courb-green-300; }
   }
 
+  &--white {
+    background-color: $white;
+    color: $cool-gray-700;
+    &:hover { background-color: $cool-gray-100; }
+  }
+
   &--yellow {
     background-color: $courb-yellow-400;
     &:hover { background-color: $courb-yellow-300; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@courbanize/courb-common-ui",
-  "version": "0.11.0",
+  "version": "0.10.1",
   "description": "Shared UI components for coUrbanize's apps",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@courbanize/courb-common-ui",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Shared UI components for coUrbanize's apps",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Part of: https://app.asana.com/0/1129724338054652/1131093391827425/f

We needed a white button class to match the share button and the comment button on the project page.

For: 
https://github.com/coUrbanize/courb-mobile/pull/1639